### PR TITLE
update deprecated set-output usage

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,13 +48,13 @@ runs:
       run: |
         # Assign inputs to variables if needed
         if [[ ${{inputs.use-cross}} == false ]]; then
-          echo "::set-output name=invoker::cargo";
+          echo "invoker=cargo" >> $GITHUB_OUTPUT;
         else
-          echo "::set-output name=invoker::cross";
+          echo "invoker=cross" >> $GITHUB_OUTPUT;
         fi
 
         if [[ -n "${{inputs.toolchain}}" ]]; then
-          echo "::set-output name=toolchain::+${{inputs.toolchain}}";
+          echo "toolchain=+${{inputs.toolchain}}" >> $GITHUB_OUTPUT;
         fi
 
     - name: Install cross if required.


### PR DESCRIPTION
See [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) for context.