### PR TITLE
Update rust-cache in test CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
           toolchain: stable
 
       - name: Enable Rust cache
-        uses: Swatinem/rust-cache@22c9328bcba27aa81a32b1bef27c7e3c78052531 # 2.0.1
+        uses: Swatinem/rust-cache@6fd3edff6979b79f87531400ad694fb7f2c84b1f # 2.2.1
         with:
           cache-on-failure: true
           workspaces: "./test/hello_world -> target"


### PR DESCRIPTION
Update `rust-cache` to the hash corresponding to 2.2.1.