### PR TITLE
Add new `repository-url` setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,14 +13,15 @@ Note - this action does not install Rust for you, you will want to install a too
 
 **Note: Inputs aren't necessarily checked to be valid by this action!**
 
-| Name            | Description                                                                                                                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `command`       | The `cargo` command to run (e.g. `build`, `test`). Required.                                                                                                                          |
-| `toolchain`     | The toolchain to use. Do not include the `+` sign (e.g. `nightly`, `beta`). Defaults to stable.                                                                                       |
-| `args`          | What arguments to pass to the cargo/cross command.                                                                                                                                    |
-| `use-cross`     | Whether to use cross instead of using cargo. If enabled, cross will automatically be installed if needed.                                                                             |
-| `cross-version` | The cross version to use. Only used if `use-cross` is enabled. If this is not set, it will default to the newest stable version of cross. `main` or `git:XYZ` are also valid options. |
-| `directory`     | Change to the specified directory prior to execution. Useful if your repo's base folder does not contain your Rust project.                                                           |
+| Name             | Description                                                                                                                                                                           |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `command`        | The `cargo` command to run (e.g. `build`, `test`). Required.                                                                                                                          |
+| `toolchain`      | The toolchain to use. Do not include the `+` sign (e.g. `nightly`, `beta`). Defaults to stable.                                                                                       |
+| `args`           | What arguments to pass to the cargo/cross command.                                                                                                                                    |
+| `use-cross`      | Whether to use cross instead of using cargo. If enabled, cross will automatically be installed if needed.                                                                             |
+| `cross-version`  | The cross version to use. Only used if `use-cross` is enabled. If this is not set, it will default to the newest stable version of cross. `main` or `git:XYZ` are also valid options. |
+| `directory`      | Change to the specified directory prior to execution. Useful if your repo's base folder does not contain your Rust project.                                                           |
+| `repository-url` | Use another git repository with `cross-version`.                                                                                                                                      |
 
 ## Example
 

--- a/action.yml
+++ b/action.yml
@@ -42,6 +42,11 @@ inputs:
     required: false
     default: ""
 
+  repository-url:
+    description: "Alternative repository to use for the cross crate"
+    required: false
+    default: ""
+
 runs:
   using: composite
   steps:
@@ -67,11 +72,19 @@ runs:
         # Install cross
         if [[ -n "${{inputs.cross-version}}" ]]; then
           if [[ "${{inputs.cross-version}}" == "main" ]]; then
-            cargo install cross --git https://github.com/cross-rs/cross --branch main
+            if [[ -n "${{inputs.repository-url}}" ]]; then
+              cargo install cross --git "${{input.repository-url}}"
+            else
+              cargo install cross --git https://github.com/cross-rs/cross --branch main
+            fi
           elif [[ "${{inputs.cross-version}}" == "git:"* ]]; then
             CROSS_VERSION_ARG="${{inputs.cross-version}}"
             CROSS_HASH="${CROSS_VERSION_ARG:4}"
-            cargo install cross --git https://github.com/cross-rs/cross --rev ${CROSS_HASH}
+            if [[ -n "${{inputs.repository-url}}" ]]; then
+              cargo install cross --git "${{inputs.repository-url}}" --rev ${CROSS_HASH}
+            else
+              cargo install cross --git https://github.com/cross-rs/cross --rev ${CROSS_HASH}
+            fi
           else
             CROSS_VERSION_ARG="--version=${{inputs.cross-version}}";
             cargo install cross --locked ${CROSS_VERSION_ARG};

--- a/action.yml
+++ b/action.yml
@@ -73,7 +73,7 @@ runs:
         if [[ -n "${{inputs.cross-version}}" ]]; then
           if [[ "${{inputs.cross-version}}" == "main" ]]; then
             if [[ -n "${{inputs.repository-url}}" ]]; then
-              cargo install cross --git "${{input.repository-url}}"
+              cargo install cross --git "${{inputs.repository-url}}"
             else
               cargo install cross --git https://github.com/cross-rs/cross --branch main
             fi


### PR DESCRIPTION
Sadly I can't just the use the last version as they removed support for platforms I need and older versions are broken when trying to build on newer rust versions. So I'll use the old version with some fixes on top. :)

If this new setting is ok with you, do you mind making a new release once merged? Thanks a lot in advance! :)