### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: "Test"
 
+permissions:
+  contents: read
+
 on:
   pull_request:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/ClementTsang/cargo-action/security/code-scanning/7](https://github.com/ClementTsang/cargo-action/security/code-scanning/7)

Add an explicit workflow-level `permissions` block near the top of `.github/workflows/test.yml` so all jobs inherit least-privilege token scopes unless overridden. For this workflow, the minimal safe baseline is:

- `contents: read`

This preserves current functionality (checkout + build/test) while preventing unintended write-capable tokens if defaults are permissive.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
